### PR TITLE
gcc-clang-delays/Stefan.Djordjevic

### DIFF
--- a/ARM/gcc_clang/delays/m0/delays.c
+++ b/ARM/gcc_clang/delays/m0/delays.c
@@ -1,11 +1,18 @@
 #include "stdint.h"
 #include "core_header.h"
 
+/* Added because of compiler specific commands */
+#ifdef _CLANG_LLVM_
+    #define SUBS_MACRO "subs"
+#else
+    #define SUBS_MACRO "sub"
+#endif
+
 void __attribute__( ( noinline, section( ".RamFunc" ) ) ) Delay_Cyc( uint32_t cycle_num )
 {
     asm volatile(
         "loopCycles%=: \n"
-        "   subs %[cycle_num], %[cycle_num], #1 \n"
+        "   " SUBS_MACRO " %[cycle_num], %[cycle_num], #1 \n"
         "   nop \n"
         "   bne loopCycles%= \n"
         : [cycle_num] "+l"(cycle_num)


### PR DESCRIPTION
added macro for asm subs command, because it differs on gcc and clang for m0 core