### PR TITLE
Clang RISC-V System Library Fix

### DIFF
--- a/RISCV/gcc_clang/CMakeLists.txt
+++ b/RISCV/gcc_clang/CMakeLists.txt
@@ -10,6 +10,10 @@ include(coreUtils)
 
 add_preinit_lib()
 
+if (${TOOLCHAIN_ID} STREQUAL "clang-llvm-riscv")
+    add_compile_definitions("CLANG_RISCV")
+endif()
+
 #include all .cmake files from cmake folder
 
 set(local_list_include "")

--- a/RISCV/gcc_clang/system/src/gigadevice/system_gd32vf103x.c
+++ b/RISCV/gcc_clang/system/src/gigadevice/system_gd32vf103x.c
@@ -44,7 +44,7 @@
 #include "rcu_typedef.h"
 #include "core_header.h"
 #include "cstdio.h"
-#if !defined (__GNUC__)
+#ifdef CLANG_RISCV
 #include <stdio.h>
 #endif
 
@@ -151,7 +151,7 @@ typedef enum {
 static const uint8_t array_divider_apb1_2[ 4 ] = { 2, 4, 8, 16 };
 static const uint8_t array_divider_ahb[ 8 ] = { 0, 1, 2, 3, 5, 6, 7, 8 };
 
-#if !defined (__GNUC__)
+#ifdef CLANG_RISCV
 // stderr stream declaration.
 FILE * const stderr;
 #endif
@@ -210,7 +210,7 @@ static system_clock_update_t system_rcu_clock_check_err( uint32_t register_addre
 
 /* -----------------------PUBLIC FUNCTION DEFINITIONS------------------------ */
 
-#if !defined(__GNUC__)
+#ifdef CLANG_RISCV
 void _exit()
 {
     // No return function in clang-llvm.


### PR DESCRIPTION
Fixes:
- Added macro definition for RISC-V Clang compiler through CMake
- Fixed guards in system library based on the macro that is added through CMake

Tested all the changes (build and programming) with 4 setups and Button 3 click:
- RISC-V Clang with Application output
- RISC-V Clang with UART
- RISC-V GCC with Application output
- RISC-V GCC with UART