### PR TITLE
Added schemas for all PIC32MZ mikromedias

### DIFF
--- a/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_3_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH100",
         "core": "",
         "delay_src_path": "",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -1,0 +1,181 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH100.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH100",
+        "core": "",
+        "delay_src_path": "",
+        "name": null,
+        "config_words": [
+            {
+                "key": "FMIIEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FETHIO",
+                "value": "ON"
+            },
+            {
+                "key": "PGL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "PMDL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "IOL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "FUSBIDIO",
+                "value": "ON"
+            },
+            {
+                "key": "FPLLIDIV",
+                "value": "DIV_3"
+            },
+            {
+                "key": "FPLLRNG",
+                "value": "RANGE_13_26_MHZ"
+            },
+            {
+                "key": "FPLLICLK",
+                "value": "PLL_POSC"
+            },
+            {
+                "key": "FPLLMULT",
+                "value": "MUL_50"
+            },
+            {
+                "key": "FPLLODIV",
+                "value": "DIV_2"
+            },
+            {
+                "key": "UPLLFSEL",
+                "value": "FREQ_12MHZ"
+            },
+            {
+                "key": "FNOSC",
+                "value": "SPLL"
+            },
+            {
+                "key": "DMTINTV",
+                "value": "WIN_127_128"
+            },
+            {
+                "key": "FSOSCEN",
+                "value": "OFF"
+            },
+            {
+                "key": "IESO",
+                "value": "OFF"
+            },
+            {
+                "key": "POSCMOD",
+                "value": "HS"
+            },
+            {
+                "key": "OSCIOFNC",
+                "value": "OFF"
+            },
+            {
+                "key": "FCKSM",
+                "value": "CSECME"
+            },
+            {
+                "key": "WDTPS",
+                "value": "PS1048576"
+            },
+            {
+                "key": "WDTSPGM",
+                "value": "STOP"
+            },
+            {
+                "key": "WINDIS",
+                "value": "NORMAL"
+            },
+            {
+                "key": "FWDTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FWDTWINSZ",
+                "value": "WINSZ_25"
+            },
+            {
+                "key": "DMTCNT",
+                "value": "DMT31"
+            },
+            {
+                "key": "FDMTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "DEBUG",
+                "value": "OFF"
+            },
+            {
+                "key": "JTAGEN",
+                "value": "OFF"
+            },
+            {
+                "key": "ICESEL",
+                "value": "ICS_PGx2"
+            },
+            {
+                "key": "TRCEN",
+                "value": "ON"
+            },
+            {
+                "key": "BOOTISA",
+                "value": "MIPS32"
+            },
+            {
+                "key": "FECCCON",
+                "value": "OFF_UNLOCKED"
+            },
+            {
+                "key": "FSLEEP",
+                "value": "OFF"
+            },
+            {
+                "key": "DBGPER",
+                "value": "PG_ALL"
+            },
+            {
+                "key": "SMCLR",
+                "value": "MCLR_NORM"
+            },
+            {
+                "key": "SOSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "SOSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "POSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "POSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "EJTAGBEN",
+                "value": "NORMAL"
+            },
+            {
+                "key": "CP",
+                "value": "OFF"
+            }
+        ]
+    }
+}

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH100.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_3_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -1,0 +1,181 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH144.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH144",
+        "core": "",
+        "delay_src_path": "",
+        "name": null,
+        "config_words": [
+            {
+                "key": "FMIIEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FETHIO",
+                "value": "ON"
+            },
+            {
+                "key": "PGL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "PMDL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "IOL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "FUSBIDIO",
+                "value": "ON"
+            },
+            {
+                "key": "FPLLIDIV",
+                "value": "DIV_3"
+            },
+            {
+                "key": "FPLLRNG",
+                "value": "RANGE_13_26_MHZ"
+            },
+            {
+                "key": "FPLLICLK",
+                "value": "PLL_POSC"
+            },
+            {
+                "key": "FPLLMULT",
+                "value": "MUL_50"
+            },
+            {
+                "key": "FPLLODIV",
+                "value": "DIV_2"
+            },
+            {
+                "key": "UPLLFSEL",
+                "value": "FREQ_12MHZ"
+            },
+            {
+                "key": "FNOSC",
+                "value": "SPLL"
+            },
+            {
+                "key": "DMTINTV",
+                "value": "WIN_127_128"
+            },
+            {
+                "key": "FSOSCEN",
+                "value": "OFF"
+            },
+            {
+                "key": "IESO",
+                "value": "OFF"
+            },
+            {
+                "key": "POSCMOD",
+                "value": "HS"
+            },
+            {
+                "key": "OSCIOFNC",
+                "value": "OFF"
+            },
+            {
+                "key": "FCKSM",
+                "value": "CSECME"
+            },
+            {
+                "key": "WDTPS",
+                "value": "PS1048576"
+            },
+            {
+                "key": "WDTSPGM",
+                "value": "STOP"
+            },
+            {
+                "key": "WINDIS",
+                "value": "NORMAL"
+            },
+            {
+                "key": "FWDTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FWDTWINSZ",
+                "value": "WINSZ_25"
+            },
+            {
+                "key": "DMTCNT",
+                "value": "DMT31"
+            },
+            {
+                "key": "FDMTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "DEBUG",
+                "value": "OFF"
+            },
+            {
+                "key": "JTAGEN",
+                "value": "OFF"
+            },
+            {
+                "key": "ICESEL",
+                "value": "ICS_PGx2"
+            },
+            {
+                "key": "TRCEN",
+                "value": "OFF"
+            },
+            {
+                "key": "BOOTISA",
+                "value": "MIPS32"
+            },
+            {
+                "key": "FECCCON",
+                "value": "OFF_UNLOCKED"
+            },
+            {
+                "key": "FSLEEP",
+                "value": "OFF"
+            },
+            {
+                "key": "DBGPER",
+                "value": "PG_ALL"
+            },
+            {
+                "key": "SMCLR",
+                "value": "MCLR_NORM"
+            },
+            {
+                "key": "SOSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "SOSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "POSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "POSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "EJTAGBEN",
+                "value": "NORMAL"
+            },
+            {
+                "key": "CP",
+                "value": "OFF"
+            }
+        ]
+    }
+}

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_4_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH144",
         "core": "",
         "delay_src_path": "",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH144.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_4_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_5_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH144",
         "core": "",
         "delay_src_path": "",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH144.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_5_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",

--- a/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/XC32/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -1,0 +1,181 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/XC32/pic32_xc32_pic32/def/PIC32MZ2048EFH144.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH144",
+        "core": "",
+        "delay_src_path": "",
+        "name": null,
+        "config_words": [
+            {
+                "key": "FMIIEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FETHIO",
+                "value": "ON"
+            },
+            {
+                "key": "PGL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "PMDL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "IOL1WAY",
+                "value": "OFF"
+            },
+            {
+                "key": "FUSBIDIO",
+                "value": "ON"
+            },
+            {
+                "key": "FPLLIDIV",
+                "value": "DIV_3"
+            },
+            {
+                "key": "FPLLRNG",
+                "value": "RANGE_13_26_MHZ"
+            },
+            {
+                "key": "FPLLICLK",
+                "value": "PLL_POSC"
+            },
+            {
+                "key": "FPLLMULT",
+                "value": "MUL_50"
+            },
+            {
+                "key": "FPLLODIV",
+                "value": "DIV_2"
+            },
+            {
+                "key": "UPLLFSEL",
+                "value": "FREQ_12MHZ"
+            },
+            {
+                "key": "FNOSC",
+                "value": "SPLL"
+            },
+            {
+                "key": "DMTINTV",
+                "value": "WIN_127_128"
+            },
+            {
+                "key": "FSOSCEN",
+                "value": "OFF"
+            },
+            {
+                "key": "IESO",
+                "value": "OFF"
+            },
+            {
+                "key": "POSCMOD",
+                "value": "HS"
+            },
+            {
+                "key": "OSCIOFNC",
+                "value": "OFF"
+            },
+            {
+                "key": "FCKSM",
+                "value": "CSECME"
+            },
+            {
+                "key": "WDTPS",
+                "value": "PS1048576"
+            },
+            {
+                "key": "WDTSPGM",
+                "value": "STOP"
+            },
+            {
+                "key": "WINDIS",
+                "value": "NORMAL"
+            },
+            {
+                "key": "FWDTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "FWDTWINSZ",
+                "value": "WINSZ_25"
+            },
+            {
+                "key": "DMTCNT",
+                "value": "DMT31"
+            },
+            {
+                "key": "FDMTEN",
+                "value": "OFF"
+            },
+            {
+                "key": "DEBUG",
+                "value": "OFF"
+            },
+            {
+                "key": "JTAGEN",
+                "value": "OFF"
+            },
+            {
+                "key": "ICESEL",
+                "value": "ICS_PGx2"
+            },
+            {
+                "key": "TRCEN",
+                "value": "OFF"
+            },
+            {
+                "key": "BOOTISA",
+                "value": "MIPS32"
+            },
+            {
+                "key": "FECCCON",
+                "value": "OFF_UNLOCKED"
+            },
+            {
+                "key": "FSLEEP",
+                "value": "OFF"
+            },
+            {
+                "key": "DBGPER",
+                "value": "PG_ALL"
+            },
+            {
+                "key": "SMCLR",
+                "value": "MCLR_NORM"
+            },
+            {
+                "key": "SOSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "SOSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "POSCGAIN",
+                "value": "GAIN_LEVEL_3"
+            },
+            {
+                "key": "POSCBOOST",
+                "value": "ON"
+            },
+            {
+                "key": "EJTAGBEN",
+                "value": "NORMAL"
+            },
+            {
+                "key": "CP",
+                "value": "OFF"
+            }
+        ]
+    }
+}

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_3_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH100",
         "core": "MICROAPTIV_FP",
         "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -1,0 +1,225 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH100.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH100",
+        "core": "MICROAPTIV_FP",
+        "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",
+        "name": null,
+        "config_registers": [
+            {
+                "fields": [
+                    {
+                        "key": "FMIIEN",
+                        "value": "01000000"
+                    },
+                    {
+                        "key": "FETHIO",
+                        "value": "02000000"
+                    },
+                    {
+                        "key": "PGL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "PMDL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IOL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FUSBIDIO",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG3"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FPLLIDIV",
+                        "value": "00000002"
+                    },
+                    {
+                        "key": "FPLLRNG",
+                        "value": "00000030"
+                    },
+                    {
+                        "key": "FPLLICLK",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FPLLMULT",
+                        "value": "00003100"
+                    },
+                    {
+                        "key": "FPLLODIV",
+                        "value": "00010000"
+                    },
+                    {
+                        "key": "UPLLFSEL",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG2"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FNOSC",
+                        "value": "00000001"
+                    },
+                    {
+                        "key": "DMTINTV",
+                        "value": "00000038"
+                    },
+                    {
+                        "key": "FSOSCEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IESO",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "POSCMOD",
+                        "value": "00000200"
+                    },
+                    {
+                        "key": "OSCIOFNC",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "FCKSM",
+                        "value": "0000c000"
+                    },
+                    {
+                        "key": "WDTPS",
+                        "value": "00140000"
+                    },
+                    {
+                        "key": "WDTSPGM",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "WINDIS",
+                        "value": "00400000"
+                    },
+                    {
+                        "key": "FWDTEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FWDTWINSZ",
+                        "value": "03000000"
+                    },
+                    {
+                        "key": "DMTCNT",
+                        "value": "5c000000"
+                    },
+                    {
+                        "key": "FDMTEN",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG1"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "DEBUG",
+                        "value": "00000003"
+                    },
+                    {
+                        "key": "JTAGEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "ICESEL",
+                        "value": "00000010"
+                    },
+                    {
+                        "key": "TRCEN",
+                        "value": "00000020"
+                    },
+                    {
+                        "key": "BOOTISA",
+                        "value": "00000040"
+                    },
+                    {
+                        "key": "FECCCON",
+                        "value": "00000300"
+                    },
+                    {
+                        "key": "FSLEEP",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "DBGPER",
+                        "value": "00007000"
+                    },
+                    {
+                        "key": "SMCLR",
+                        "value": "00008000"
+                    },
+                    {
+                        "key": "SOSCGAIN",
+                        "value": "00030000"
+                    },
+                    {
+                        "key": "SOSCBOOST",
+                        "value": "00040000"
+                    },
+                    {
+                        "key": "POSCGAIN",
+                        "value": "00180000"
+                    },
+                    {
+                        "key": "POSCBOOST",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "EJTAGBEN",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG0"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP3"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP2"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP1"
+            },
+            {
+                "fields": {
+                    "key": "CP",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP0"
+            }
+        ]
+    }
+}

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH100/PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH100.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_3_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH100_Mikromedia_3_for_PIC32MZ",

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH144.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_4_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_4_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH144",
         "core": "MICROAPTIV_FP",
         "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ.schema
@@ -1,0 +1,225 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH144.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH144_Mikromedia_4_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH144",
+        "core": "MICROAPTIV_FP",
+        "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",
+        "name": null,
+        "config_registers": [
+            {
+                "fields": [
+                    {
+                        "key": "FMIIEN",
+                        "value": "01000000"
+                    },
+                    {
+                        "key": "FETHIO",
+                        "value": "02000000"
+                    },
+                    {
+                        "key": "PGL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "PMDL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IOL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FUSBIDIO",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG3"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FPLLIDIV",
+                        "value": "00000002"
+                    },
+                    {
+                        "key": "FPLLRNG",
+                        "value": "00000030"
+                    },
+                    {
+                        "key": "FPLLICLK",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FPLLMULT",
+                        "value": "00003100"
+                    },
+                    {
+                        "key": "FPLLODIV",
+                        "value": "00010000"
+                    },
+                    {
+                        "key": "UPLLFSEL",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG2"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FNOSC",
+                        "value": "00000001"
+                    },
+                    {
+                        "key": "DMTINTV",
+                        "value": "00000038"
+                    },
+                    {
+                        "key": "FSOSCEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IESO",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "POSCMOD",
+                        "value": "00000200"
+                    },
+                    {
+                        "key": "OSCIOFNC",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "FCKSM",
+                        "value": "0000c000"
+                    },
+                    {
+                        "key": "WDTPS",
+                        "value": "00140000"
+                    },
+                    {
+                        "key": "WDTSPGM",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "WINDIS",
+                        "value": "00400000"
+                    },
+                    {
+                        "key": "FWDTEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FWDTWINSZ",
+                        "value": "03000000"
+                    },
+                    {
+                        "key": "DMTCNT",
+                        "value": "5c000000"
+                    },
+                    {
+                        "key": "FDMTEN",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG1"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "DEBUG",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "JTAGEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "ICESEL",
+                        "value": "00000010"
+                    },
+                    {
+                        "key": "TRCEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "BOOTISA",
+                        "value": "00000040"
+                    },
+                    {
+                        "key": "FECCCON",
+                        "value": "00000300"
+                    },
+                    {
+                        "key": "FSLEEP",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "DBGPER",
+                        "value": "00007000"
+                    },
+                    {
+                        "key": "SMCLR",
+                        "value": "00008000"
+                    },
+                    {
+                        "key": "SOSCGAIN",
+                        "value": "00030000"
+                    },
+                    {
+                        "key": "SOSCBOOST",
+                        "value": "00040000"
+                    },
+                    {
+                        "key": "POSCGAIN",
+                        "value": "00180000"
+                    },
+                    {
+                        "key": "POSCBOOST",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "EJTAGBEN",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG0"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP3"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP2"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP1"
+            },
+            {
+                "fields": {
+                    "key": "CP",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP0"
+            }
+        ]
+    }
+}

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -1,0 +1,225 @@
+{
+    "compiler_flags": "",
+    "linker_flags": "",
+    "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH144.json",
+    "flash": 2097152,
+    "ram": 524288,
+    "settings": {
+        "clock": "200",
+        "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",
+        "mcu": "PIC32MZ2048EFH144",
+        "core": "MICROAPTIV_FP",
+        "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",
+        "name": null,
+        "config_registers": [
+            {
+                "fields": [
+                    {
+                        "key": "FMIIEN",
+                        "value": "01000000"
+                    },
+                    {
+                        "key": "FETHIO",
+                        "value": "02000000"
+                    },
+                    {
+                        "key": "PGL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "PMDL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IOL1WAY",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FUSBIDIO",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG3"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FPLLIDIV",
+                        "value": "00000002"
+                    },
+                    {
+                        "key": "FPLLRNG",
+                        "value": "00000030"
+                    },
+                    {
+                        "key": "FPLLICLK",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FPLLMULT",
+                        "value": "00003100"
+                    },
+                    {
+                        "key": "FPLLODIV",
+                        "value": "00010000"
+                    },
+                    {
+                        "key": "UPLLFSEL",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG2"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "FNOSC",
+                        "value": "00000001"
+                    },
+                    {
+                        "key": "DMTINTV",
+                        "value": "00000038"
+                    },
+                    {
+                        "key": "FSOSCEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "IESO",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "POSCMOD",
+                        "value": "00000200"
+                    },
+                    {
+                        "key": "OSCIOFNC",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "FCKSM",
+                        "value": "0000c000"
+                    },
+                    {
+                        "key": "WDTPS",
+                        "value": "00140000"
+                    },
+                    {
+                        "key": "WDTSPGM",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "WINDIS",
+                        "value": "00400000"
+                    },
+                    {
+                        "key": "FWDTEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "FWDTWINSZ",
+                        "value": "03000000"
+                    },
+                    {
+                        "key": "DMTCNT",
+                        "value": "5c000000"
+                    },
+                    {
+                        "key": "FDMTEN",
+                        "value": "00000000"
+                    }
+                ],
+                "key": "DEVCFG1"
+            },
+            {
+                "fields": [
+                    {
+                        "key": "DEBUG",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "JTAGEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "ICESEL",
+                        "value": "00000010"
+                    },
+                    {
+                        "key": "TRCEN",
+                        "value": "00000000"
+                    },
+                    {
+                        "key": "BOOTISA",
+                        "value": "00000040"
+                    },
+                    {
+                        "key": "FECCCON",
+                        "value": "00000300"
+                    },
+                    {
+                        "key": "FSLEEP",
+                        "value": "00000400"
+                    },
+                    {
+                        "key": "DBGPER",
+                        "value": "00007000"
+                    },
+                    {
+                        "key": "SMCLR",
+                        "value": "00008000"
+                    },
+                    {
+                        "key": "SOSCGAIN",
+                        "value": "00030000"
+                    },
+                    {
+                        "key": "SOSCBOOST",
+                        "value": "00040000"
+                    },
+                    {
+                        "key": "POSCGAIN",
+                        "value": "00180000"
+                    },
+                    {
+                        "key": "POSCBOOST",
+                        "value": "00200000"
+                    },
+                    {
+                        "key": "EJTAGBEN",
+                        "value": "40000000"
+                    }
+                ],
+                "key": "DEVCFG0"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP3"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP2"
+            },
+            {
+                "fields": {
+                    "key": "Hidden",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP1"
+            },
+            {
+                "fields": {
+                    "key": "CP",
+                    "value": "ffffffff"
+                },
+                "key": "DEVCP0"
+            }
+        ]
+    }
+}

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -4,6 +4,7 @@
     "def_path": "PIC32/mikroC/pic32_mikroc_pic32mzef/def/PIC32MZ2048EFH144.json",
     "flash": 2097152,
     "ram": 524288,
+    "board_regex":"MIKROMEDIA_5_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
         "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",

--- a/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
+++ b/PIC32/mikroC/schemas/PIC32MZ2048EFH144/PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ.schema
@@ -7,7 +7,7 @@
     "board_regex":"MIKROMEDIA_5_FOR_PIC32MZ_.+",
     "settings": {
         "clock": "200",
-        "scheme": "PIC32MZ2048EFH144_Mikromedia_5_for_PIC32MZ",
+        "scheme": "MIKROMEDIA",
         "mcu": "PIC32MZ2048EFH144",
         "core": "MICROAPTIV_FP",
         "delay_src_path": "delays/microaptiv_fp/__lib_delays.c",


### PR DESCRIPTION
List of Mikromedias that now will have the dedicated clock schema file:
- Mikromedia 3 for PIC32MZ Capacitive;
- Mikromedia 3 for PIC32MZ Capacitive FPI with frame;
- Mikromedia 3 for PIC32MZ Capacitive FPI with bezel;
- Mikromedia 4 for PIC32MZ Capacitive;
- Mikromedia 4 for PIC32MZ Capacitive FPI with frame;
- Mikromedia 4 for PIC32MZ Capacitive FPI with bezel;
- Mikromedia 5 for PIC32MZ Capacitive;
- Mikromedia 5 for PIC32MZ Capacitive FPI with frame;
- Mikromedia 5 for PIC32MZ Capacitive FPI with bezel;
- Mikromedia 3 for PIC32MZ Resistive;
- Mikromedia 3 for PIC32MZ Resistive FPI with frame;
- Mikromedia 4 for PIC32MZ Resistive;
- Mikromedia 4 for PIC32MZ Resistive FPI with frame;
- Mikromedia 5 for PIC32MZ Resistive;
- Mikromedia 5 for PIC32MZ Resistive FPI with frame.

Changes applied to clock within these schemas:
- Input clock range for PLL input switched from 8-16 MHz to 13-26 MHz as all these Mikromedia Boards use 24MHz external crystal oscillator (verified with all schemas that we have on our website);
- PLL Multiplier decreased from 100 to 50 to reach 200MHz clock speed eventually using 24MHz / 3 / 2 equation.