### PR TITLE
Added custom find_package_me cmake function

### DIFF
--- a/utils/cmake/mikroeUtilsCommon.cmake
+++ b/utils/cmake/mikroeUtilsCommon.cmake
@@ -1,10 +1,13 @@
 #############################################################################
 ## Function to find the packages with better error message handling.
 #############################################################################
-function(find_package_me PACKAGE_NAME REQUIRED_FLAG)
-    # Set default value for REQUIRED_FLAG if not provided
-    if(NOT DEFINED REQUIRED_FLAG)
-        set(REQUIRED_FLAG OPTIONAL)
+function(find_package_me PACKAGE_NAME)
+    # Set the default value of REQUIRED_FLAG to OPTIONAL
+    set(REQUIRED_FLAG "OPTIONAL")
+
+    # If a second argument is passed, treat it as REQUIRED_FLAG
+    if(ARGC GREATER 1)
+        set(REQUIRED_FLAG ${ARGV1})
     endif()
 
     # Attempt to find the package without the REQUIRED flag

--- a/utils/cmake/mikroeUtilsCommon.cmake
+++ b/utils/cmake/mikroeUtilsCommon.cmake
@@ -2,11 +2,16 @@
 ## Function to find the packages with better error message handling.
 #############################################################################
 function(find_package_me PACKAGE_NAME REQUIRED_FLAG)
+    # Set default value for REQUIRED_FLAG if not provided
+    if(NOT DEFINED REQUIRED_FLAG)
+        set(REQUIRED_FLAG OPTIONAL)
+    endif()
+
     # Attempt to find the package without the REQUIRED flag
     find_package(${PACKAGE_NAME})
 
     # If the package is not found, manually trigger an error with a detailed message
-    if (NOT ${PACKAGE_NAME}_FOUND)
+    if (NOT ${PACKAGE_NAME}_FOUND AND ${REQUIRED_FLAG} STREQUAL "REQUIRED")
         message(FATAL_ERROR "
         ****************************************************************************
         !!! FATAL ERROR: Setup configuration is incorrect !!!

--- a/utils/cmake/mikroeUtilsCommon.cmake
+++ b/utils/cmake/mikroeUtilsCommon.cmake
@@ -1,4 +1,28 @@
 #############################################################################
+## Function to find the packages with better error message handling.
+#############################################################################
+function(find_package_me PACKAGE_NAME REQUIRED_FLAG)
+    # Attempt to find the package without the REQUIRED flag
+    find_package(${PACKAGE_NAME})
+
+    # If the package is required and not found, trigger a custom error message
+    if(${REQUIRED_FLAG} STREQUAL "REQUIRED" AND NOT ${PACKAGE_NAME}_FOUND)
+        message("****************************************************************************")
+        message(" !!! FATAL ERROR: Setup configuration is incorrect !!!       ")
+        message(" If you are using graphical project, ensure that your setup has a display.")
+        message(" If you are using CAN/DMA/USB/Ethernet/etc. project, ensure that MCU")
+        message("    that you are using has this module supported by using this link:")
+        message("https://github.com/MikroElektronika/mikrosdk_v2/blob/master/SUPPORTED_CHIP_LIST.md")
+        message("****************************************************************************")
+        message(FATAL_ERROR)
+    elseif(NOT ${REQUIRED_FLAG} STREQUAL "REQUIRED" AND NOT ${PACKAGE_NAME}_FOUND)
+        message(WARNING "!!! WARNING: Optional package ${PACKAGE_NAME} not found.")
+    else()
+        message(STATUS "Found package: ${PACKAGE_NAME}")
+    endif()
+endfunction()
+
+#############################################################################
 ## Including this directory will ensure that all necessary support files
 ## are visible to any project.
 #############################################################################

--- a/utils/cmake/mikroeUtilsCommon.cmake
+++ b/utils/cmake/mikroeUtilsCommon.cmake
@@ -16,7 +16,7 @@ function(find_package_me PACKAGE_NAME)
     # If the package is not found, manually trigger an error with a detailed message
     if (NOT ${PACKAGE_NAME}_FOUND AND ${REQUIRED_FLAG} STREQUAL "REQUIRED")
         message(FATAL_ERROR "
-        ****************************************************************************
+      ****************************************************************************
         !!! FATAL ERROR: Setup configuration is incorrect !!!
         If you are using graphical project, ensure that your setup has a display.
         If you are using CAN/DMA/USB/Ethernet/etc. project, ensure that the MCU

--- a/utils/cmake/mikroeUtilsCommon.cmake
+++ b/utils/cmake/mikroeUtilsCommon.cmake
@@ -5,20 +5,17 @@ function(find_package_me PACKAGE_NAME REQUIRED_FLAG)
     # Attempt to find the package without the REQUIRED flag
     find_package(${PACKAGE_NAME})
 
-    # If the package is required and not found, trigger a custom error message
-    if(${REQUIRED_FLAG} STREQUAL "REQUIRED" AND NOT ${PACKAGE_NAME}_FOUND)
-        message("****************************************************************************")
-        message(" !!! FATAL ERROR: Setup configuration is incorrect !!!       ")
-        message(" If you are using graphical project, ensure that your setup has a display.")
-        message(" If you are using CAN/DMA/USB/Ethernet/etc. project, ensure that MCU")
-        message("    that you are using has this module supported by using this link:")
-        message("https://github.com/MikroElektronika/mikrosdk_v2/blob/master/SUPPORTED_CHIP_LIST.md")
-        message("****************************************************************************")
-        message(FATAL_ERROR)
-    elseif(NOT ${REQUIRED_FLAG} STREQUAL "REQUIRED" AND NOT ${PACKAGE_NAME}_FOUND)
-        message(WARNING "!!! WARNING: Optional package ${PACKAGE_NAME} not found.")
-    else()
-        message(STATUS "Found package: ${PACKAGE_NAME}")
+    # If the package is not found, manually trigger an error with a detailed message
+    if (NOT ${PACKAGE_NAME}_FOUND)
+        message(FATAL_ERROR "
+        ****************************************************************************
+        !!! FATAL ERROR: Setup configuration is incorrect !!!
+        If you are using graphical project, ensure that your setup has a display.
+        If you are using CAN/DMA/USB/Ethernet/etc. project, ensure that the MCU
+        that you are using supports this module. Refer to this link:
+        https://github.com/MikroElektronika/mikrosdk_v2/blob/master/SUPPORTED_CHIP_LIST.md
+        ****************************************************************************
+        ")
     endif()
 endfunction()
 


### PR DESCRIPTION
This PR is connected to [SWMIKSDK-1720](https://jira.mikroe.com/browse/SWMIKSDK-1720)
It is also connected to PR in [mikrosdk_v2 repo](https://github.com/MikroElektronika/mikrosdk_v2/pull/107)

Added custom find_package_me CMake function to mikroeUtilsCommon.cmake with user-friendly error message when package is not found. Use cases:
- Designer project was opened with the setup that don't have display (PD only)
- SDK project was opened with MCU that doesn't have this module supported (link to the MCU-Module dependencies is present in the message)