### PR TITLE
Update checkIndexes.yaml wit AVR in regex

### DIFF
--- a/.github/workflows/checkIndexes.yaml
+++ b/.github/workflows/checkIndexes.yaml
@@ -13,7 +13,7 @@ on:
       regex:
         type: string
         description: Regex to use when searching for indexed items
-        default: "arm_gcc_clang|arm_mikroc|clocks|database|dspic|^images$|mikroe_utils|pic|preinit|riscv|schemas|unit_test_lib|.+[device|tool]_support$"
+        default: "arm_gcc_clang|arm_mikroc|clocks|database|dspic|^images$|mikroe_utils|avr|pic|preinit|riscv|schemas|unit_test_lib|.+[device|tool]_support$"
       fix:
         type: boolean
         description: Fix the broken links with new ones?
@@ -27,7 +27,7 @@ on:
     - cron: "0/30 7-16 * * 1-5"  # Every 30 minutes, between 07:00 AM and 04:59 PM, Monday through Friday
 
 env:
-  GLOBAL_REGEX: "arm_gcc_clang|arm_mikroc|clocks|database|dspic|^images$|mikroe_utils|pic|preinit|riscv|schemas|unit_test_lib|.+[device|tool]_support$"
+  GLOBAL_REGEX: "arm_gcc_clang|arm_mikroc|clocks|database|dspic|^images$|mikroe_utils|avr|pic|preinit|riscv|schemas|unit_test_lib|.+[device|tool]_support$"
 
 jobs:
   manual_run:


### PR DESCRIPTION
Initially 2 AVR packages avr_mikroc_avr_lte64k and avr_mikroc_avr_gt64k were not copied because they were not handled by regex.