### PR TITLE
Updated CSV file link to always use Live and added guards for indexing Codegrip Packs

### DIFF
--- a/.github/workflows/MCUsReleaseTest.yaml
+++ b/.github/workflows/MCUsReleaseTest.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Update and upload new database
         run: |
-          python -u scripts/reupload_databases.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ secrets.PROG_DEBUG_CODEGRIP_TEST }} ${{ secrets.PROG_DEBUG_MIKROPROG }} ${{ github.event.inputs.release_version }} "latest" "Test"
+          python -u scripts/reupload_databases.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ secrets.PROG_DEBUG_MIKROPROG }} ${{ github.event.inputs.release_version }} "latest" "Test"
 
       - name: Run Index Script
         env:
@@ -104,7 +104,7 @@ jobs:
           ES_INDEX_LIVE: ${{ secrets.ES_INDEX_LIVE }}
         run: |
             echo "Indexing to Test."
-            python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ secrets.ES_INDEX_TEST }} ${{ secrets.PROG_DEBUG_CODEGRIP_TEST }} "False" ${{ github.event.inputs.release_version }} "False" "False"
+            python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ secrets.ES_INDEX_TEST }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} "False" ${{ github.event.inputs.release_version }} "False" "False"
 
       - name: Notify Mattermost - Test ready
         env:

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -497,7 +497,7 @@ def index_codegrip_packs(es: Elasticsearch, index_name, doc_codegrip):
         # Release only for packages with release date lower or equal than current date
         if package_release_date <= current_date:
             previous_version, new_version, mcus_to_index = CODEGRIP.get_version(es, index_name, package_items[package]['package_name'], package_items[package]['mcus'], package_items[package]['package_version'])
-            if previous_version != new_version:
+            if previous_version != new_version and len(mcus_to_index):
                 doc = {
                     "name": package_items[package]['package_name'],
                     "display_name": package_items[package]['display_name'],


### PR DESCRIPTION
With this approach Codegrip Packs won't be indexed if they have no MCUs supported (applicable for SDK release days for example).