### PR TITLE
Added separate workflow for releasing CODEGRIP packages

### DIFF
--- a/.github/workflows/releaseCodegripPackages.yaml
+++ b/.github/workflows/releaseCodegripPackages.yaml
@@ -12,11 +12,11 @@ on:
       start_date:
         type: string
         description: First date for codegrip releases to release (better use csv, not spreadsheet to see the date)
-        default: "12.06.2025"
+        default: "2025-06-12"
       end_date:
         type: string
         description: Last date for codegrip releases (better use csv, not spreadsheet to see the date)
-        default: "12.06.2025"
+        default: "2025-06-13"
   schedule:
     - cron: "0 6 12-13 4 *" # 6:00 AM, 12th-13th of June
 

--- a/.github/workflows/releaseCodegripPackages.yaml
+++ b/.github/workflows/releaseCodegripPackages.yaml
@@ -57,7 +57,55 @@ jobs:
 
       - name: Update database for packaging
         run: |
-          python -u scripts/reupload_databases.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ secrets.PROG_DEBUG_MIKROPROG }} "latest" "latest" ${{ github.event.inputs.select_index }} "--mcus_only" "True"
+          python -u scripts/reupload_databases.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ secrets.PROG_DEBUG_MIKROPROG }} "latest" "latest" ${{ github.event.inputs.select_index }} "--mcus_only" "False"
+
+      - name: Add GitHub Actions credentials
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      # TODO: Revert once ERP Database upload API is fixed
+      # - name: Commit and Push Changes
+      #   run: |
+      #     if [[ ${{ github.event.inputs.select_index }} == "Live" ]]; then
+      #       DB_NAME="necto_db.db"
+      #     else
+      #       DB_NAME="necto_db_dev.db"
+      #     fi
+      #     STATUS=$(git status --short "$DB_NAME")
+      #     if [ -z "$STATUS" ]; then
+      #       echo "No changes made to $DB_NAME";
+      #     else
+      #       echo "Updating with new $DB_NAME";
+      #       echo "test"
+      #       git pull
+      #       git add $DB_NAME
+      #       git commit -m "Updated $DB_NAME with latest merged release."
+      #       git push
+      #       if [[ ${{ github.event.inputs.select_index }} == "Live" ]]; then
+      #         curl --location --request POST '${{ secrets.ERP_DB_IMPORT_API }}' \
+      #         --header 'Authorization: Basic ${{ secrets.ERP_DB_IMPORT_KEY }}'
+      #       fi
+      #     fi
+
+      - name: Commit and Push Changes
+        run: |
+          if [[ ${{ github.event.inputs.select_index }} == "Live" ]]; then
+            DB_NAME="necto_db.db"
+          else
+            DB_NAME="necto_db_dev.db"
+          fi
+          STATUS=$(git status --short "$DB_NAME")
+          if [ -z "$STATUS" ]; then
+            echo "No changes made to $DB_NAME";
+          else
+            echo "Updating with new $DB_NAME";
+            echo "test"
+            git pull
+            git add $DB_NAME
+            git commit -m "Updated $DB_NAME with latest merged release."
+            git push
+          fi
 
       - name: Run Index Script
         env:

--- a/.github/workflows/releaseCodegripPackages.yaml
+++ b/.github/workflows/releaseCodegripPackages.yaml
@@ -1,0 +1,84 @@
+name: Release Codegrip Packages Separately
+
+on:
+  workflow_dispatch:
+    inputs:
+      select_index:
+        type: choice
+        description: Index as test or live
+        options:
+          - Test
+          - Live
+      start_date:
+        type: string
+        description: First date for codegrip releases to release (better use csv, not spreadsheet to see the date)
+        default: "12.06.2025"
+      end_date:
+        type: string
+        description: Last date for codegrip releases (better use csv, not spreadsheet to see the date)
+        default: "12.06.2025"
+  schedule:
+    - cron: "0 6 12-13 4 *" # 6:00 AM, 12th-13th of June
+
+jobs:
+  release-codegrip-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authorize Mikroe Actions App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.MIKROE_ACTIONS }}
+          private-key: ${{ secrets.MIKROE_ACTIONS_KEY_AUTHORIZE }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache Python packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements/shared.txt
+          sudo apt-get install p7zip-full
+
+      - name: Update database for packaging
+        run: |
+          python -u scripts/reupload_databases.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ secrets.PROG_DEBUG_MIKROPROG }} "latest" "latest" ${{ github.event.inputs.select_index }} "--mcus_only" "True"
+
+      - name: Run Index Script
+        env:
+          ES_HOST: ${{ secrets.ES_HOST }}
+          ES_USER: ${{ secrets.ES_USER }}
+          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+        run: |
+          if [[ ${{ github.event.inputs.select_index }} == "Test" ]]; then
+            echo "Indexing to Test."
+            python -u scripts/index_codegrip_packages.py ${{ secrets.ES_INDEX_TEST }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ github.event.inputs.start_date }} ${{ github.event.inputs.end_date }} > message.txt
+            else
+            echo "Indexing to Live."
+            python -u scripts/index_codegrip_packages.py ${{ secrets.ES_INDEX_LIVE }} ${{ secrets.PROG_DEBUG_CODEGRIP_LIVE }} ${{ github.event.inputs.start_date }} ${{ github.event.inputs.end_date }} > message.txt
+          fi
+
+      - name: Send notification to Mattermost - SDK Team
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL_SDK }}
+        run: |
+          cat message.txt
+          MESSAGE=$(cat message.txt)
+          curl -X POST -H 'Content-Type: application/json' \
+          --data "{\"text\": \"$MESSAGE\"}" \
+          $MATTERMOST_WEBHOOK_URL

--- a/scripts/index_codegrip_packages.py
+++ b/scripts/index_codegrip_packages.py
@@ -1,0 +1,173 @@
+import os, time, argparse, json
+from elasticsearch import Elasticsearch
+from datetime import datetime, timezone
+
+import support as support
+import read_codegrip_index as CODEGRIP
+
+def remove_duplicate_indexed_files(es : Elasticsearch, index_name):
+    # Search query to use
+    query_search = {
+        "size": 5000,
+        "query": {
+            "match_all": {}
+        }
+    }
+    # All package types to check for
+    typeCheck = [
+        'mcu',
+        'preinit',
+        'database',
+        'mcu_clocks',
+        'mcu_schemas',
+        'unit_test_lib',
+        'mikroe_utils_common'
+    ]
+
+    # Search the base with provided query
+    num_of_retries = 1
+    while num_of_retries <= 10:
+        try:
+            response = es.search(index=index_name, body=query_search)
+            if not response['timed_out']:
+                break
+        except:
+            print("Executing search query - retry number %i" % num_of_retries)
+        num_of_retries += 1
+
+    checkDict = {}
+    db_version = None
+    for eachHit in response['hits']['hits']:
+        if not 'name' in eachHit['_source']:
+            continue ## TODO - Check newly created bare metal package (is it created correctly)
+        name = eachHit['_source']['name']
+        if name == 'database':
+            db_version = eachHit['_source']['version']
+        if '_type' in eachHit:
+            type = eachHit['_type']
+            id = eachHit['_id']
+            if eachHit['_source']['type'] in typeCheck:
+                if name in checkDict:
+                    checkDict[name]['count'] += 1
+                    checkDict[name]['id'].append([id, type])
+                else:
+                    checkDict.update({name: { 'count': 1, 'id': [[id, type]]}})
+
+    # Proceed to remove all found IDs
+    for eachPackageName in checkDict.keys():
+        if checkDict[eachPackageName]['count'] > 1:
+            for eachId in checkDict[eachPackageName]['id']:
+                print("Removed %s/%s" % (eachId[1], eachId[0]))
+                response = es.delete(index=index_name, id=eachId[0], doc_type=None)
+
+    return db_version
+
+def index_codegrip_packs(es: Elasticsearch, index_name, doc_codegrip, start_date, end_date):
+    package_items = CODEGRIP.convert_item_to_json(doc_codegrip, True)
+
+    # Get the current time in UTC
+    current_time = datetime.now(timezone.utc).replace(microsecond=0)
+    # If you specifically want the 'Z' at the end instead of the offset
+    current_date = current_time.isoformat().replace('+00:00', 'Z')
+
+    print(f"Codegrip Packages Release action has been triggered for {start_date} - {end_date} dates!")
+    print("Here are the changes:")
+
+    for package in package_items:
+        package_release_date = datetime.strptime(package_items[package]['release_date'], "%Y-%m-%dT%H:%M:%SZ").date()
+        # Release only for packages with release date in between of requested days
+        if package_release_date >= start_date and package_release_date <= end_date:
+            previous_version, new_version, mcus_to_index = CODEGRIP.get_version(es, index_name, package_items[package]['package_name'], package_items[package]['mcus'], package_items[package]['package_version'])
+            if previous_version != new_version and len(mcus_to_index):
+                
+                if package_items[package]['release_date'] == current_date:
+                    published_at_date = current_date
+                else:
+                    published_at_date = "2023-11-16T06:00:00Z"
+
+                doc = {
+                    "name": package_items[package]['package_name'],
+                    "display_name": package_items[package]['display_name'],
+                    "author": "MIKROE",
+                    "hidden": False,
+                    "type": "programmer_dfp",
+                    "version": new_version,
+                    "package_version": package_items[package]['package_version'],
+                    # Index it to the date that is not visible in NECTO.
+                    # After script is finished make sure to run 
+                    # https://github.com/MikroElektronika/mikrosdk_v2/actions/workflows/updateReleaseIndexDate.yaml
+                    # with the settings set according to release spreadsheet.
+                    "published_at": published_at_date,
+                    "category": "CODEGRIP Device Pack",
+                    "download_link": package_items[package]['download_link'],
+                    "package_changed": True,
+                    "install_location": package_items[package]['install_location'],
+                    "dependencies": json.loads(package_items[package]['dependencies']),
+                    "mcus": mcus_to_index
+                }
+
+                # Kibana v8 requires _type to be in body in order to have doc_type defined
+                doc['_type'] = '_doc'
+                resp = es.index(index=index_name, doc_type=None, id=package_items[package]['package_name'], body=doc)
+
+                if ('created' == resp['result'] or 'updated' == resp['result']):
+                    print(f"- {package_items[package]['package_name']}")
+                    print(f'  - "version": {previous_version} -> {new_version}')
+                    print(f'  - "published_at": "{published_at_date}"')
+
+if __name__ == '__main__':
+    # First, check for arguments passed
+    def str2bool(v):
+        if isinstance(v, bool):
+            return v
+        if v.lower() in ('yes', 'true', 't', 'y', '1'):
+            return True
+        elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+            return False
+        else:
+            raise argparse.ArgumentTypeError('Boolean value expected.')
+
+    # Get arguments
+    parser = argparse.ArgumentParser(description="Index Codegrip Packages.")
+    parser.add_argument("select_index", help="Provided index name")
+    parser.add_argument('doc_codegrip', type=str, help='Spreadsheet table download link.')
+    parser.add_argument('start_date', type=str, help='First date for Codegrip Packages release.')
+    parser.add_argument('end_date', type=str, help='Last date for Codegrip Packages release.')
+    parser.add_argument("--es_host", help="Elasticsearch host value", default="")
+    parser.add_argument("--es_user", help="Elasticsearch username value", default="")
+    parser.add_argument("--es_password", help="Elasticsearch password value", default="")
+    args = parser.parse_args()
+
+    # For local debug purposes
+    if args.es_host and args.es_user and args.es_password:
+        es_host = args.es_host
+        es_user = args.es_user
+        es_password = args.es_password
+    else:
+        es_host = os.environ['ES_HOST']
+        es_user = os.environ['ES_USER']
+        es_password = os.environ['ES_PASSWORD']
+
+    # Elasticsearch instance used for indexing
+    num_of_retries = 1
+    print("Trying to connect to ES.")
+    while True:
+        es = Elasticsearch([es_host], http_auth=(es_user, es_password))
+        if es.ping():
+            break
+        # Wait 1 second and try again if connection fails
+        if 10 == num_of_retries:
+            # Exit if it fails 10 times, something is wrong with the server
+            raise ValueError("Connection to ES failed!")
+        print(f"Connection retry: {num_of_retries}")
+        num_of_retries += 1
+
+        time.sleep(1)
+
+    # Remove any previous multiple indexes, if any
+    db_version = remove_duplicate_indexed_files(
+        es, args.select_index
+    )
+
+    index_codegrip_packs(es, args.select_index, args.doc_codegrip, args.start_date, args.end_date)
+

--- a/scripts/index_codegrip_packages.py
+++ b/scripts/index_codegrip_packages.py
@@ -111,4 +111,3 @@ if __name__ == '__main__':
         time.sleep(1)
 
     index_codegrip_packs(es, args.select_index, args.doc_codegrip, args.start_date, args.end_date)
-


### PR DESCRIPTION
This workflow will be useful for the days when MCUs are prereleased, but CSV for CODEGRIP is uploaded later.