### PR TITLE
Update Board.sql

### DIFF
--- a/utils/databases/queries/Board.sql
+++ b/utils/databases/queries/Board.sql
@@ -85,6 +85,7 @@ WHERE
         OR (Boards.soldered_device LIKE '%%1%')
         OR (Boards.mikrobus_count LIKE '%%1%')
         OR (Boards.display_socket LIKE '%%1%')
+	OR (Boards.uid LIKE '%%1%')
     )
 
 ORDER BY CASE


### PR DESCRIPTION
This change is neede for the PD to recognize the board. As initially it was taking the `name` column from the database, not the `uid` and it didn't work for the boards where uid and name don't match.